### PR TITLE
[feat] add new command YOCO.copyTextWithFilePath

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off",
+  "YOCO.includeFilePath": true
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,17 @@
         "mac": "cmd+shift+c",
         "when": "editorTextFocus"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "YOCO",
+      "properties": {
+        "YOCO.includeFilePath": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include file path in copied text"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
         "command": "YOCO.copyTextWithFilePath",
         "title": "Copy Text With FileName as Comment"
       }
+    ],
+    "keybindings": [
+      {
+        "command": "YOCO.copyTextWithFilePath",
+        "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c",
+        "when": "editorTextFocus"
+      }
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "YOCO.helloWorld",
-        "title": "Hello World"
+        "command": "YOCO.copyTextWithFilePath",
+        "title": "Copy Text With FileName as Comment"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,26 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
-  // This line of code will only be executed once when your extension is activated
-  console.log('Congratulations, your extension "YOCO" is now active!');
+  // YOCO.copyTextWithFilePath
+  // 가장 상단에 `//${fileName}` 형식의 주석을 추가한 형태로 텍스르를 복사한다.
+  const disposable = vscode.commands.registerCommand("YOCO.copyTextWithFilePath", () => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
 
-  // The command has been defined in the package.json file
-  // Now provide the implementation of the command with registerCommand
-  // The commandId parameter must match the command field in package.json
-  const disposable = vscode.commands.registerCommand("YOCO.helloWorld", () => {
-    // The code you place here will be executed every time your command is executed
-    // Display a message box to the user
-    vscode.window.showInformationMessage("Hello World from YOCO!");
+    const document = editor.document;
+
+    const selection = editor.selection;
+    const filePath = document.uri.path;
+    const text = document.getText(selection);
+
+    const comment = `//${filePath}`;
+
+    vscode.env.clipboard.writeText(comment + text);
   });
 
   context.subscriptions.push(disposable);
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,12 +10,15 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const document = editor.document;
-
     const selection = editor.selection;
-    const filePath = document.uri.path;
     const text = document.getText(selection);
 
-    const comment = `//${filePath}`;
+    // settings의 YOCO.includeFilePath가 true일 경우에만 실행
+    const includeFilePath = vscode.workspace.getConfiguration("YOCO").get("includeFilePath");
+
+    const filePath = document.uri.path;
+
+    const comment = `//${includeFilePath ? filePath : filePath.split("/").pop()}\n`;
 
     vscode.env.clipboard.writeText(comment + text);
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
   // YOCO.copyTextWithFilePath
-  // 가장 상단에 `//${fileName}` 형식의 주석을 추가한 형태로 텍스르를 복사한다.
-  const disposable = vscode.commands.registerCommand("YOCO.copyTextWithFilePath", () => {
+  // 가장 상단에 `// ${fileName}` 형식의 주석을 추가한 형태로 텍스트를 복사한다.
+  const disposable = vscode.commands.registerCommand("YOCO.copyTextWithFilePath", async () => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
       return;
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const filePath = document.uri.path;
 
-    const comment = `//${includeFilePath ? filePath : filePath.split("/").pop()}\n`;
+    const comment = `// ${includeFilePath ? filePath : filePath.split("/").pop()}\n`;
 
     vscode.env.clipboard.writeText(comment + text);
   });


### PR DESCRIPTION
Closes [issue link]

## Decsription

- 간단한 복사 기능과, 관련된 설정 옵션, 단축키 추가입니다.
- command 추가: YOCO.copyTextWithFilePath
- configuration 추가 : YOCO.includeFilePath
- key binding 추가( cmd+shift+c / ctrl+shift+c )

## ETC

- 관련된 테스트 코드 추가는 일정상 생략하였습니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 테스트를 완료하였고, 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
